### PR TITLE
nodeng 22.18.0.2

### DIFF
--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -7,19 +7,19 @@ on:
   workflow_dispatch:
 jobs:
   linux:
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.04
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.05
     with:
       cmake-workflow-preset: LinuxRelease
       runon: ubuntu-latest
     secrets: inherit
   linux-arm64:
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.04
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.05
     with:
       cmake-workflow-preset: LinuxRelease
       runon: ubuntu-24.04-arm
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.04
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.05
     with:
       cmake-workflow-preset: WindowsRelease
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.04
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.05
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
       artifact_pattern: "*.tar.xz"
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     secrets: inherit


### PR DESCRIPTION
nodeng v22.18.0.1 has issues
```
-- Could NOT find nodeng (missing: NODENG_VER) 
```
because the `NODENG_VER` is empty because it doesn't have this fix to a bug introduced just before the v22.18.0.1 release https://github.com/externpro/externpro/commit/0070397f109bb36bc44615e3d201cdb8a69c2dd8