### PR TITLE
externpro 25.07.14

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,0 +1,4 @@
+{
+  "message": "xpro version 24.13.0.3 tag",
+  "tag": "xpv24.13.0.3"
+}

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,0 @@
-tag: xpv24.13.0.2
-message: "xpro version 24.13.0.2 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,17 +14,18 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.14
+    secrets:
+      automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
-      cmake-workflow-preset: LinuxRelease
-    secrets: inherit
+      cmake_workflow_preset_suffix: Release
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
-    with:
-      cmake-workflow-preset: DarwinRelease
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.14
     secrets: inherit
+    with:
+      cmake_workflow_preset_suffix: Release
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
-    with:
-      cmake-workflow-preset: WindowsRelease
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.14
     secrets: inherit
+    with:
+      cmake_workflow_preset_suffix: Release

--- a/.github/workflows/xpinit.yml
+++ b/.github/workflows/xpinit.yml
@@ -1,0 +1,12 @@
+name: xpInit externpro
+permissions:
+  contents: write
+  pull-requests: write
+  packages: write
+on:
+  workflow_dispatch:
+jobs:
+  init:
+    uses: externpro/externpro/.github/workflows/init-externpro.yml@main
+    secrets:
+      automation_token: ${{ secrets.XPRO_TOKEN }}

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.14
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,9 +8,9 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.14
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}
     secrets:
-      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}
+      automation_token: ${{ secrets.XPRO_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.14`

## Changes

- Updated `.devcontainer` to externpro `25.07.14`
- Previous HEAD: `7fbe4a89a2342591ae16da31892e98638ea27f8c`
- New HEAD: `4d8695ae8527ccfa043337bafbb4abf3b5aa549e`
- Created `.github/release-tag.json` (tag: `xpv24.13.0.3`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv24.13.0.3\`
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 xpbuild.yml: preserved repo key `jobs.macos.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.cmake_workflow_preset_suffix` (renamed from `cmake-workflow-preset`)
- 🔧 workflow_call input renamed (kebab-case → snake_case): `cmake-workflow-preset` -> `cmake_workflow_preset_suffix`
- ✓ xpbuild.yml: Synced from template
- ✓ xpinit.yml: Created new workflow from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
