### PR TITLE
externpro 25.07.14-2-g9f2b023

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 24.13.0.3 tag",
-  "tag": "xpv24.13.0.3"
+  "message": "xpro version 24.13.0.4 tag",
+  "tag": "xpv24.13.0.4"
 }

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.14
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@main
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.14-2-g9f2b023`

## Changes

- Updated `.devcontainer` to externpro `25.07.14-2-g9f2b023`
- Previous HEAD: `4d8695ae8527ccfa043337bafbb4abf3b5aa549e`
- New HEAD: `9f2b0238b77a6ed0cd3f79070ee08b5980903bf5`
- Updated `.github/release-tag.json` (tag: `xpv24.13.0.4`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv24.13.0.4\`
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.cmake_workflow_preset_suffix`
- 🔧 xpbuild.yml: preserved repo key `jobs.macos.with.cmake_workflow_preset_suffix`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.cmake_workflow_preset_suffix`
- ✓ xprelease.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
