### PR TITLE
externpro 26.01.1-9-g32f46e4

### DIFF
--- a/.github/release-tag.json
+++ b/.github/release-tag.json
@@ -1,4 +1,4 @@
 {
-  "message": "xpro version 24.13.0.3 tag",
-  "tag": "xpv24.13.0.3"
+  "message": "xpro version 24.13.0.4 tag",
+  "tag": "xpv24.13.0.4"
 }

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -14,18 +14,18 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.14
+    uses: externpro/externpro/.github/workflows/build-linux.yml@26.01.1
     secrets:
       automation_token: ${{ secrets.GHCR_TOKEN }}
     with:
       cmake_workflow_preset_suffix: Release
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.14
+    uses: externpro/externpro/.github/workflows/build-macos.yml@26.01.1
     secrets: inherit
     with:
       cmake_workflow_preset_suffix: Release
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.14
+    uses: externpro/externpro/.github/workflows/build-windows.yml@26.01.1
     secrets: inherit
     with:
       cmake_workflow_preset_suffix: Release

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -34,7 +34,7 @@ jobs:
   # Upload build artifacts as release assets
   release-from-build:
     if: github.event_name == 'workflow_dispatch'
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.14
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@26.01.1
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   tag:
     if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
-    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.14
+    uses: externpro/externpro/.github/workflows/tag-release.yml@26.01.1
     with:
       merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
-cmake_minimum_required(VERSION 3.31)
-set(CMAKE_PROJECT_TOP_LEVEL_INCLUDES .devcontainer/cmake/xproinc.cmake)
+cmake_minimum_required(VERSION 4.3)
 project(nodeng VERSION 24.13.0)
 # https://nodejs.org/dist/v24.13.0/SHASUMS256.txt
 set(SHA256_Linux e798599612f4bb71333a3397ab0d095fd62214e115aea45aa858a145fc72d67e) # node-v24.13.0-linux-x64.tar.xz


### PR DESCRIPTION
## Summary

Update externpro submodule to `26.01.1-9-g32f46e4`

## Changes

- Updated `.devcontainer` to externpro `26.01.1-9-g32f46e4`
- Previous HEAD: `d84d2a18346536b5a2738b219fd61715699b50ec`
- New HEAD: `32f46e487d55910b4a899c06d96fa4753b959826`
- Updated `.github/release-tag.json` (tag: `xpv24.13.0.4`)
  - Optional: add the "release:tag" label to trigger tagging, release builds, and draft release notes
- If you add the \"release:tag\" label, the tag will be \`xpv24.13.0.4\`
  - WARNING: that tag already exists; update \".github/release-tag.json\" to the next desired tag value
    - https://github.com/externpro/nodeng/blob/xpupdate-26.01.1-9-g32f46e4-26121611877-1/.github/release-tag.json
- Updated caller workflows to match templates

### Workflow Update Report

- 🔧 xpbuild.yml: preserved repo key `jobs.linux.with.cmake_workflow_preset_suffix`
- 🔧 xpbuild.yml: preserved repo key `jobs.macos.with.cmake_workflow_preset_suffix`
- 🔧 xpbuild.yml: preserved repo key `jobs.windows.with.cmake_workflow_preset_suffix`
- ✓ xpbuild.yml: Synced from template
- ✓ xprelease.yml: Synced from template
- ✓ xptag.yml: Synced from template

---

*This PR was created automatically by GitHub Actions*
